### PR TITLE
Add MonarchRouter

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -6031,5 +6031,12 @@
       "homepage": "https://github.com/y-okudera/NeumorphismKit",
       "tags": ["neumorphism", "uicomponents", "swift", "ios", "storyboard"]
     }
+    , {
+      "title": "MonarchRouter",
+      "category": "app-routing",
+      "description": "Declarative state- and URL-based router. Complex automatic View Controllers hierarchy transitions. Time-tested server-side conventions.",
+      "homepage": "https://github.com/nikans/MonarchRouter",
+      "tags": ["routing", "router", "swift", "ios", "declarative", "state-based", "url", "redux", "reactive"]
+    }
   ]
 }


### PR DESCRIPTION
- **Project Name**: Monarch Router

- **Project URL**: https://github.com/nikans/MonarchRouter

- **Project Description**: 
Declarative state- and URL-based router. Complex automatic View Controllers hierarchy transitions, decoupling them. Time-tested server-side conventions implemented for iOS.

- **Why it should be added to `awesome-swift`**:
I wanted to create a server-side-like router that will be able to manage View Controllers hierarchy automatically. From backend development world MonarchRouter borrows routes-handling mechanics (inspired by Symphony and Perfect), from front-end originally a Redux-style flow. 
It's capable of handling a complex hierarchies autonomously, completely decoupling VCs from each other, i.e. opening modals and handling their sub-hierarchy, unwinding back to a common parent to present a new stack. 
Couple of years ago I used it in production in the app with a quite complex navigation ([Atlas](https://apps.apple.com/us/app/atlasbiomed/id1372132260), browsing DNA reports an all), it works marvels. Now I'd like to share it with a community.

- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
